### PR TITLE
Edit Intent post to cut AI-slop patterns

### DIFF
--- a/app/(blog)/_posts/intent.mdx
+++ b/app/(blog)/_posts/intent.mdx
@@ -45,17 +45,17 @@ charts suggested. Now the distinctions are visibly breaking down.
 Models blur the roles. Specs become interfaces, engineers prompt,
 designers scaffold.
 
-The **product engineer** is where these threads converge. They work across
-domain models, UX flows, and infrastructure, not to own a layer but to
-keep intent intact as it passes between them.
+The **product engineer** is a much needed site of convergence. They work across
+domain models, UX flows, and infrastructure, not to own a layer but to ensure
+intent survives translation.
 
 When boundaries collapse, coordination shifts from handoffs to coherence.
 
 ## Structural taste
 
 In this collapsed stack, 2025 brought "vibe coding": shaping whole systems
-in dialogue with the machine, leaning on tacit feel rather than explicit
-logic.
+in dialogue with the machine,
+leaning on tacit understanding rather than explicit logic.
 
 But vibe is fragile and doesn't scale. When it works, it’s resting on
 something firmer: **structural taste**.
@@ -70,8 +70,8 @@ about how things should be, not a universal standard of high art.
 It’s less about being smarter than about _giving a shit_ when the machine
 makes it easy not to.
 
-When AI responses are all 'good enough,' taste is what refuses the median
-outcome.
+When AI responses are all 'good enough,' taste is the
+refusal to accept the median outcome.
 
 It’s caring about the semantic precision of the domain model, the threshold
 of a loading spinner, the specific tone of a zero-state. These small things
@@ -140,7 +140,7 @@ Spaceship Earth is our shared platform. We’re constantly pushing updates.
 
 ## Conclusion
 
-Whether you are deepening the stack or expanding into management, the job is
+Whether you are deepening the stack or expanding into management, the requirement is
 the same: hold the loop open. Interpret, structure, guide, and stay
 responsible for what the loop puts into the world.
 

--- a/app/(blog)/_posts/intent.mdx
+++ b/app/(blog)/_posts/intent.mdx
@@ -9,15 +9,13 @@ tags: product
 Intent doesn't flow in one direction. It loops.
 
 Design informs systems, engineering shapes experience, and every artifact
-feeds back into the next. As AI takes over, strict divisions
-between roles collapse. The line between implementation and interpretation
-fades.
+feeds back into the next. As AI absorbs the work, strict divisions between
+roles collapse, and the line between implementation and interpretation fades.
 
-The distance between idea and execution disappears, forcing a
-divergence in how we build.
+As the distance between idea and execution disappears, how we build splits
+in two.
 
-This is an attempt to surface that shift. How do we build when the loop
-includes us?
+How do we build when the loop includes us?
 
 ---
 
@@ -26,16 +24,14 @@ includes us?
 ## Loops, not pipelines
 
 Feedback loops have always shaped good software. What’s changing is the
-speed, depth, and density of those loops—and who’s inside them.
+speed, depth, and density of those loops, and who’s inside them.
 
-In a loop, there is no "before" and "after." You don’t write the
-code and wait for the result. You shape the system and feel it
-respond—immediately, subtly. Every commit is a conversation. Every
-prompt is a bet.
+In a loop, there is no "before" and "after." You don’t write the code and
+wait for the result. You shape the system and feel it respond. Each commit
+is a move in a conversation with it; each prompt is a bet.
 
-This changes the ontology of engineering. It’s not about specifying a
-system and stepping back. It’s about inhabiting the loop long enough to
-orient it.
+Engineering stops being about specifying a system and stepping back. It
+becomes about staying in the loop long enough to steer it.
 
 ## The collapse of boundaries
 
@@ -44,42 +40,45 @@ orient it.
 > [@graycoding](https://x.com/graycoding/status/1993348014606631262)
 
 Design, engineering, and product were never as separate as their org
-charts suggested. Now, the distinctions are visibly breaking down.
+charts suggested. Now the distinctions are visibly breaking down.
 
-Models blur the interface. Specs become interfaces. Engineers prompt.
-Designers scaffold.
+Models blur the roles. Specs become interfaces, engineers prompt,
+designers scaffold.
 
-In this context, the **product engineer** is a much needed
-site of convergence. They work across domain models, UX flows, and
-infrastructure shape—not to “own” a layer, but to ensure intent survives
-translation.
+The **product engineer** is where these threads converge. They work across
+domain models, UX flows, and infrastructure, not to own a layer but to
+keep intent intact as it passes between them.
 
-When boundaries collapse, coordination happens not through handoff, but through **coherence**.
+When boundaries collapse, coordination shifts from handoffs to coherence.
 
 ## Structural taste
 
-In this collapsed stack, 2025 saw the rise of "vibe coding"—shaping end-to-end systems in dialogue with the machine,
-leaning on tacit understanding rather than explicit logic.
+In this collapsed stack, 2025 brought "vibe coding": shaping whole systems
+in dialogue with the machine, leaning on tacit feel rather than explicit
+logic.
 
-But vibe is fragile. Vibe doesn't scale. When it works, it’s grounded in
-something deeper: **structural taste**.
+But vibe is fragile and doesn't scale. When it works, it’s resting on
+something firmer: **structural taste**.
 
 > “You can’t vibe your way to a good product no matter how good your
 > AI tooling is.”
 > —[@thenimmyjeutron](https://x.com/thenimmyjeutron/status/1918761295119032633?s=46&t=sMs-A_dNCLw3V0W97IuPNg)
 
-Structural taste is judgment in architecture. It is not a universal standard of high art; it is a specific, local conviction about how things should be.
+Structural taste is judgment in architecture: a specific, local conviction
+about how things should be, not a universal standard of high art.
 
-It’s not about being smarter; it’s about _giving a shit_ when the machine makes it easy not to.
+It’s less about being smarter than about _giving a shit_ when the machine
+makes it easy not to.
 
-In a world where AI responses are 'good enough,' taste is the act of resistance. It is the refusal to accept the median outcome.
+When AI responses are all 'good enough,' taste is what refuses the median
+outcome.
 
-It’s caring about the semantic precision of the domain model. The threshold of a loading spinner. The specific tone of a zero-state.
-These are the small things that define whether a system is habitable.
+It’s caring about the semantic precision of the domain model, the threshold
+of a loading spinner, the specific tone of a zero-state. These small things
+decide whether a system is habitable.
 
-The active preservation of coherence against entropy—the rigorous consequence of taste-driven choices—is really the essence of **intent**.
-
-Vibe carries the energy; taste provides the container.
+Holding a system coherent against entropy, choice by choice, is what intent
+actually means here.
 
 > “Prompting is thinking. The sharper your thoughts, the better the
 > prompts, the better the outputs.”
@@ -87,14 +86,16 @@ Vibe carries the energy; taste provides the container.
 
 ## The second half of AI: the return of the manager
 
-As the friction of implementation dissolves, the role of the engineer expands in two directions simultaneously.
+As the friction of implementation dissolves, the engineer’s role expands in
+two directions.
 
 **We go deeper.**
-Engineers use AI to tackle complexity that was previously insurmountable.
-We become comprehensive designers of intricate architectures.
+Engineers use AI to take on complexity that was previously insurmountable.
+We become comprehensive designers of systems we couldn’t hold before.
 
 **We go wider.**
-If product engineering is the collapse of the stack, this is the compression of execution.
+If product engineering is the collapse of the stack, this is the
+compression of execution.
 
 > “The second half of AI – starting now – will shift focus from
 > solving problems to defining them. [...] To thrive, we’ll need a
@@ -102,31 +103,36 @@ If product engineering is the collapse of the stack, this is the compression of 
 > product manager.” — Shunyu Yao,
 > [The Second Half](https://ysymyth.github.io/The-Second-Half/)
 
-Here, the end state of the engineer is the manager—but not the manager of people. The **cybernetic manager** directs the compiler, the agent, and the business logic simultaneously.
+Here the engineer’s end state is a manager, but not of people. The
+**cybernetic manager** directs the compiler, the agent, and the business
+logic at once.
 
 In this low-latency loop, the linear relationship dissolves.
 Implementation informs intent as much as intent causes implementation.
 
 ## Comprehensive design
 
-Whichever mode we operate in, strict specialization by role is dead. We are all systems thinkers now.
-What remains is specialization by taste, and a deeper question of responsibility.
+Whichever mode we operate in, strict specialization by role is dead. We are
+all systems thinkers now. What remains is specialization by taste, and a
+deeper question of responsibility.
 
-This shift creates a new weight. As our leverage scales, so does the impact of our design choices.
-Every system we shape shapes something larger—economic, ecological, social.
+That leverage comes with weight. As it scales, so does the impact of our
+design choices; every system we shape shapes something larger: economic,
+ecological, social.
 
-Buckminster Fuller, the original comprehensive designer, framed "Spaceship Earth" as a design challenge:
-a closed system with limited inputs and global interdependence.
+Buckminster Fuller, the original comprehensive designer, framed "Spaceship
+Earth" as a design challenge: a closed system with limited inputs and
+global interdependence.
 
 > “We are all astronauts on a little spaceship called Earth. But it
 > did not come with an instructions manual.”
 > — Buckminster Fuller
 
 As the loop tightens, the boundary between 'lab' and 'world' becomes porous.
-What we treat as local variables increasingly triggers global side effects.
+What we treat as local variables now triggers global side effects.
 
-The challenge is to build systems that don’t just function, but cohere.
-Systems that treat life not as an edge case, but as a design constraint.
+The challenge is to build systems that cohere, not just function. Systems
+that treat life as a design constraint, not an edge case.
 
 Spaceship Earth is our shared platform. We’re constantly pushing updates.
 
@@ -134,8 +140,8 @@ Spaceship Earth is our shared platform. We’re constantly pushing updates.
 
 ## Conclusion
 
-Intent initiates; responsibility sustains.
+Whether you are deepening the stack or expanding into management, the job is
+the same: hold the loop open. Interpret, structure, guide, and stay
+responsible for what the loop puts into the world.
 
-Whether you are deepening the stack or expanding into management, the requirement is the same: to hold the loop open. To interpret, to structure, and to guide.
-
-The product is not the end. It’s another beginning.
+Shipping the product isn’t the end of that. It’s where the next loop starts.


### PR DESCRIPTION
## Summary

- Editing pass on `app/(blog)/_posts/intent.mdx` ("Let Intent Circulate") to strip AI-writing tells while preserving the argument and the author's voice.
- Removed: binary-contrast pileups ("not through handoff, but through coherence"), dramatic fragmentation, colon reveals, importance puffery ("changes the ontology of engineering", "the essence of intent"), banned/empty words (`intricate`, `really`, `simultaneously`, "In this context", "In a world where"), and the summary-recap conclusion.
- Kept intact: all block quotes and citations, the section structure, the `We go deeper / We go wider` scaffolding, and **two** load-bearing contrasts that still land — "Intent doesn't flow in one direction. It loops." and "…life as a design constraint, not an edge case."

## Test plan

- [ ] `yarn dev` and open the post — confirm MDX renders, quotes and links intact, TOC still populates.
- [ ] Read it aloud: the voice should still be recognizably the author's, just sharper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)